### PR TITLE
Add async evaluation with concurrent API calls

### DIFF
--- a/OutputGeneration.py
+++ b/OutputGeneration.py
@@ -1,5 +1,5 @@
 import os
-from openai import AzureOpenAI
+from openai import AzureOpenAI, AsyncAzureOpenAI
 from dotenv import load_dotenv
 from typing import Any
 
@@ -34,4 +34,20 @@ def GenerateOutput(Prompt: str, **Variables: Any) -> str:
         ]
     )
     
+    return Response.choices[0].message.content
+
+
+async def GenerateOutputAsync(Prompt: str, **Variables: Any) -> str:
+    """Asynchronous version of GenerateOutput using AsyncAzureOpenAI."""
+    FormattedPrompt = Prompt.format(**Variables)
+    Client = AsyncAzureOpenAI(
+        api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+        api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
+        azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT")
+    )
+    Response = await Client.chat.completions.create(
+        model=os.getenv("AZURE_OPENAI_DEPLOYMENT_NAME"),
+        messages=[{"role": "user", "content": FormattedPrompt}]
+    )
+    await Client.close()
     return Response.choices[0].message.content

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -24,5 +24,29 @@ class MetricsTestCase(unittest.TestCase):
         self.assertAlmostEqual(Metrics['Recall'], 0.75)
         self.assertAlmostEqual(Metrics['F1'], 2/3)
 
+    def test_async_perfect_predictions(self):
+        DataFrame = pd.DataFrame({'text': ['a', 'b'], 'label': ['yes', 'no']})
+        Predictions = iter(['yes', 'no'])
+        async def SideEffect(Prompt, **Variables):
+            return next(Predictions)
+        with patch('PromptEvaluation.GenerateOutputAsync', side_effect=SideEffect):
+            Metrics, _ = EvaluatePrompt('template', DataFrame, ['text'], 'label', UseAsync=True)
+        self.assertAlmostEqual(Metrics['Accuracy'], 1.0)
+        self.assertAlmostEqual(Metrics['Precision'], 1.0)
+        self.assertAlmostEqual(Metrics['Recall'], 1.0)
+        self.assertAlmostEqual(Metrics['F1'], 1.0)
+
+    def test_async_partial_predictions(self):
+        DataFrame = pd.DataFrame({'text': ['a', 'b', 'c'], 'label': ['yes', 'no', 'yes']})
+        Predictions = iter(['no', 'no', 'yes'])
+        async def SideEffect(Prompt, **Variables):
+            return next(Predictions)
+        with patch('PromptEvaluation.GenerateOutputAsync', side_effect=SideEffect):
+            Metrics, _ = EvaluatePrompt('template', DataFrame, ['text'], 'label', UseAsync=True)
+        self.assertAlmostEqual(Metrics['Accuracy'], 2/3)
+        self.assertAlmostEqual(Metrics['Precision'], 0.75)
+        self.assertAlmostEqual(Metrics['Recall'], 0.75)
+        self.assertAlmostEqual(Metrics['F1'], 2/3)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `GenerateOutputAsync` for Azure OpenAI requests
- support asynchronous evaluation with `UseAsync` option
- run concurrent API calls using `asyncio.gather`
- test both synchronous and asynchronous evaluation paths

## Testing
- `pip install pandas --quiet`
- `pip install scikit-learn --quiet`
- `pip install python-dotenv --quiet`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fa139ebdc8320893b345bd6a13eaa