### PR TITLE
Fix EvaluatePrompt indexing

### DIFF
--- a/PromptEvaluation.py
+++ b/PromptEvaluation.py
@@ -7,6 +7,8 @@ from dotenv import load_dotenv
 load_dotenv()
 
 async def EvaluatePrompt(Prompt, Dataframe):
+    Dataframe = Dataframe.reset_index(drop=True)
+
     Client = AsyncAzureOpenAI(
         api_key=os.getenv("AZURE_OPENAI_API_KEY"),
         api_version=os.getenv("AZURE_OPENAI_API_VERSION"),
@@ -36,7 +38,7 @@ async def EvaluatePrompt(Prompt, Dataframe):
             print(f"Error processing row {Index}: {e}")
             return Index, "Error"
     
-    Tasks = [ProcessRow(Index, Row) for Index, Row in Dataframe.iterrows()]
+    Tasks = [ProcessRow(Position, Row) for Position, (_, Row) in enumerate(Dataframe.iterrows())]
     Results = await asyncio.gather(*Tasks)
     
     Predictions = [""] * len(Dataframe)

--- a/main.py
+++ b/main.py
@@ -32,4 +32,4 @@ async def Main():
     print(f"Accuracy: {Accuracy:.3f}")
 
 if __name__ == "__main__":
-    await Main()
+    asyncio.run(Main())


### PR DESCRIPTION
## Summary
- reset index in EvaluatePrompt to avoid list assignment errors
- iterate with enumerate when creating tasks
- run async entry point with `asyncio.run` in `main.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410f366b608320b692d9dfe4f2f7b0