### PR TITLE
Add confusion matrix to prompt evaluation

### DIFF
--- a/PromptEvaluation.py
+++ b/PromptEvaluation.py
@@ -163,4 +163,8 @@ async def EvaluatePrompt(Prompt, Dataframe, TargetLabel):
         else 0.0
     )
 
-    return Accuracy, Precision, Recall, F1, Dataframe
+    ConfusionMatrix = pd.crosstab(
+        Dataframe["label"], Dataframe["ExtractedLabel"], dropna=False
+    )
+
+    return Accuracy, Precision, Recall, F1, Dataframe, ConfusionMatrix

--- a/PromptEvolution.py
+++ b/PromptEvolution.py
@@ -42,7 +42,7 @@ async def RetryAzureOpenAICall(CallFunction, MaxRetries=25, InitialDelay=1):
                 print(f"Azure OpenAI call failed after {MaxRetries + 1} attempts")
                 raise LastException
 
-async def AnalyzeErrorsAndRevisePrompt(Prompt, Dataframe, TargetLabels):
+async def AnalyzeErrorsAndRevisePrompt(Prompt, Dataframe, TargetLabels, ConfusionMatrix):
     """
     Analyzes prediction errors and generates a revised prompt to reduce errors.
     
@@ -50,6 +50,7 @@ async def AnalyzeErrorsAndRevisePrompt(Prompt, Dataframe, TargetLabels):
         Prompt (str): The original prompt used for predictions
         Dataframe (pd.DataFrame): DataFrame containing 'ModelPrediction', 'ExtractedLabel', and other columns
         TargetLabels (list): List of valid labels that the model should use
+        ConfusionMatrix (pd.DataFrame): Confusion matrix of labels vs predictions
         
     Returns:
         str: Revised prompt based on error analysis
@@ -79,12 +80,15 @@ async def AnalyzeErrorsAndRevisePrompt(Prompt, Dataframe, TargetLabels):
     # First Azure OpenAI call: Analyze errors
     ErrorAnalysisPrompt = f"""
     Analyze the following prediction errors from a text classification model:
-    
+
     Original Prompt: {Prompt}
-    
+
     Error Examples:
     {ErrorAnalysisInput}
-    
+
+    Confusion Matrix:
+    {ConfusionMatrix}
+
     Please analyze these errors and identify:
     1. Common patterns in the misclassifications
     2. Potential ambiguities in the original prompt

--- a/main.py
+++ b/main.py
@@ -73,6 +73,7 @@ async def Main(MaxIterations=5, AccuracyThreshold=0.8):
         CurrentRecall,
         CurrentF1,
         CurrentEvaluationResults,
+        CurrentConfusionMatrix,
     ) = await EvaluatePrompt(CurrentPrompt, TrainingData, TargetLabel)
     print(
         f"Initial Accuracy: {CurrentAccuracy:.3f} | Precision: {CurrentPrecision:.3f} | Recall: {CurrentRecall:.3f} | F1: {CurrentF1:.3f}"
@@ -105,7 +106,12 @@ async def Main(MaxIterations=5, AccuracyThreshold=0.8):
         print(f"Number of evaluation results: {len(CurrentEvaluationResults)}")
         ErrorCount = len(CurrentEvaluationResults[CurrentEvaluationResults['ExtractedLabel'] != CurrentEvaluationResults['label']])
         print(f"Number of errors found: {ErrorCount}")
-        RevisedPrompt = await AnalyzeErrorsAndRevisePrompt(CurrentPrompt, CurrentEvaluationResults, TargetLabel)
+        RevisedPrompt = await AnalyzeErrorsAndRevisePrompt(
+            CurrentPrompt,
+            CurrentEvaluationResults,
+            TargetLabel,
+            CurrentConfusionMatrix,
+        )
         print(f"Revised Prompt: {RevisedPrompt}")
         
         # Evaluate revised prompt
@@ -116,6 +122,7 @@ async def Main(MaxIterations=5, AccuracyThreshold=0.8):
             RevisedRecall,
             RevisedF1,
             RevisedEvaluationResults,
+            RevisedConfusionMatrix,
         ) = await EvaluatePrompt(RevisedPrompt, TrainingData, TargetLabel)
         print(
             f"Revised Accuracy: {RevisedAccuracy:.3f} | Precision: {RevisedPrecision:.3f} | Recall: {RevisedRecall:.3f} | F1: {RevisedF1:.3f}"
@@ -129,6 +136,7 @@ async def Main(MaxIterations=5, AccuracyThreshold=0.8):
         CurrentRecall = RevisedRecall
         CurrentF1 = RevisedF1
         CurrentEvaluationResults = RevisedEvaluationResults
+        CurrentConfusionMatrix = RevisedConfusionMatrix
         
         # Store iteration results
         IterationResults.append({


### PR DESCRIPTION
## Summary
- compute a confusion matrix in `EvaluatePrompt`
- pass the matrix through the workflow for prompt revision
- embed the matrix into error analysis prompts
- update main workflow to handle new return values

## Testing
- `python -m unittest test_prompt_evaluation.py`

------
https://chatgpt.com/codex/tasks/task_e_68415dc948248320adc12aae3ccc7d70