### PR TITLE
Add SaveResultsWithBestPrompt utility

### DIFF
--- a/PromptTracingUtils.py
+++ b/PromptTracingUtils.py
@@ -1,0 +1,9 @@
+import json
+
+
+def SaveResultsWithBestPrompt(IterationResults, BestPrompt, FilePath='PromptTracing.json'):
+    """Save iteration results with the best prompt appended."""
+    DataToSave = list(IterationResults)
+    DataToSave.append({"BestPromptByF1": BestPrompt})
+    with open(FilePath, 'w') as JsonFile:
+        json.dump(DataToSave, JsonFile, indent=2)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from sklearn.model_selection import train_test_split
 from PromptEvaluation import EvaluatePrompt
 from PromptEvolution import AnalyzeErrorsAndRevisePrompt
 from PromptSelector import PromptPool, SelectPrompt
+from PromptTracingUtils import SaveResultsWithBestPrompt
 
 
 def GetBestPromptByF1(Results):
@@ -225,10 +226,10 @@ async def Main(MaxIterations=5, AccuracyThreshold=0.85, Epsilon=0.1):
         f"Validation Accuracy: {ValidationAccuracy:.3f} | Precision: {ValidationPrecision:.3f} | Recall: {ValidationRecall:.3f} | F1: {ValidationF1:.3f}"
     )
 
-    # Save results to JSON file
-    with open('PromptTracing.json', 'w') as JsonFile:
-        json.dump(IterationResults, JsonFile, indent=2)
+    # Save results to JSON file with best prompt appended
+    SaveResultsWithBestPrompt(IterationResults, BestPrompt, 'PromptTracing.json')
     print("Results Saved")
+
 
 if __name__ == "__main__":
     asyncio.run(Main())


### PR DESCRIPTION
## Summary
- add `SaveResultsWithBestPrompt` helper to append best F1 prompt to PromptTracing.json
- integrate new helper into `main.py` to store the final prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684177d79f3c8320a3ae897b252e6e61